### PR TITLE
MVP into Development

### DIFF
--- a/eukaryote/commands/interactive_cli_command.py
+++ b/eukaryote/commands/interactive_cli_command.py
@@ -24,14 +24,11 @@ class InteractiveCliCommand(TextAttackCommand):
             "Train a model with train",
         ]
         model_choices = [
+            "bert-base-uncased",
             "distilbert-base-uncased",
-            "BERT_mini",
-            "BERT_regular",
-            "BERT_large",
-            "BagOfWords",
         ]
-        dataset_choices = ["rotten_tomatoes"]
-        attack_choices = ["textfooler"]
+        dataset_choices = ["yelp_polarity", "rotten_tomatoes"]
+        attack_choices = ["bert-attack", "deepwordbug", "textfooler"]
 
         questions = [
             {
@@ -68,29 +65,49 @@ class InteractiveCliCommand(TextAttackCommand):
 
         # semi-redundant code here, but I have a feeling keeping them separate is more clear+extensible?
         try:
-            prompt_action = prompt(questions[0], vi_mode=True)  # decide which action to take
+            prompt_action = prompt(
+                questions[0], vi_mode=True
+            )  # decide which action to take
             if prompt_action["action"] == "Attack a model with attack_eval":
-                prompt_args = prompt([questions[i] for i in [1,2,3,4]], vi_mode=True)  # set up to select arbitrary subset of questions
+                prompt_args = prompt(
+                    [questions[i] for i in [1, 2, 3, 4]], vi_mode=True
+                )  # set up to select arbitrary subset of questions
                 fake_parser = ArgumentParser()
                 # copy t4a_attack_eval_command.py's register_subcommand behavior
                 shared.add_arguments_model(fake_parser)
                 shared.add_arguments_dataset(fake_parser, default_split="test")
                 shared.add_arguments_attack(fake_parser)
                 fake_parser.set_defaults(attack=True)
-                fake_args = fake_parser.parse_args([f"--{k}={v}" for k, v in prompt_args.items() if k != 'confirmation']) # format for parser
+                fake_args = fake_parser.parse_args(
+                    [
+                        f"--{k}={v}"
+                        for k, v in prompt_args.items()
+                        if k != "confirmation"
+                    ]
+                )  # format for parser
                 T4A_AttackEvalCommand().run(args=fake_args)
             elif prompt_action["action"] == "Train a model with train":
-                prompt_args = prompt([questions[i] for i in [1,2,4]], vi_mode=True) # no need to ask q3, attack recipe. Set up to select arbitrary subset of questions
+                prompt_args = prompt(
+                    [questions[i] for i in [1, 2, 4]], vi_mode=True
+                )  # no need to ask q3, attack recipe. Set up to select arbitrary subset of questions
                 fake_parser = ArgumentParser()
                 # copy t4a_train_command.py's register_subcommand behavior
                 shared.add_arguments_model(fake_parser)
                 shared.add_arguments_dataset(fake_parser, default_split="train")
                 shared.add_arguments_train(fake_parser, default_split_eval="test")
                 fake_parser.set_defaults(attack=False)
-                fake_args = fake_parser.parse_args([f"--{k}={v}" for k, v in prompt_args.items() if k != 'confirmation']) # format for parser
+                fake_args = fake_parser.parse_args(
+                    [
+                        f"--{k}={v}"
+                        for k, v in prompt_args.items()
+                        if k != "confirmation"
+                    ]
+                )  # format for parser
                 T4A_TrainCommand().run(args=fake_args)
             elif prompt_action["action"] == "Adversarial training with attack_train":
-                prompt_args = prompt([questions[i] for i in [1,2,3,4]], vi_mode=True) # set up to select arbitrary subset of questions
+                prompt_args = prompt(
+                    [questions[i] for i in [1, 2, 3, 4]], vi_mode=True
+                )  # set up to select arbitrary subset of questions
                 fake_parser = ArgumentParser()
                 # copy t4a_attack_train_command.py's register_subcommand behavior
                 shared.add_arguments_model(fake_parser)
@@ -98,7 +115,13 @@ class InteractiveCliCommand(TextAttackCommand):
                 shared.add_arguments_attack(fake_parser)
                 shared.add_arguments_train(fake_parser)
                 fake_parser.set_defaults(attack=True)
-                fake_args = fake_parser.parse_args([f"--{k}={v}" for k, v in prompt_args.items() if k != 'confirmation']) # format for parser
+                fake_args = fake_parser.parse_args(
+                    [
+                        f"--{k}={v}"
+                        for k, v in prompt_args.items()
+                        if k != "confirmation"
+                    ]
+                )  # format for parser
                 T4A_AttackTrainCommand().run(args=fake_args)
         except InvalidArgument:
             print("No available choices")

--- a/eukaryote/commands/interactive_cli_command.py
+++ b/eukaryote/commands/interactive_cli_command.py
@@ -1,0 +1,92 @@
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
+import sys
+from InquirerPy import prompt
+from InquirerPy.exceptions import InvalidArgument
+from InquirerPy.validator import PathValidator
+from pyfiglet import Figlet
+
+from eukaryote import Attacker, CommandLineAttackArgs, DatasetArgs, ModelArgs
+from eukaryote.commands import TextAttackCommand
+from eukaryote.commands.t4a_attack_eval_command import T4A_AttackEvalCommand
+from eukaryote.commands.t4a_train_command import T4A_TrainCommand
+from eukaryote.commands.t4a_attack_train_command import T4A_AttackTrainCommand
+import eukaryote.t4a.shared as shared
+
+
+class InteractiveCliCommand(TextAttackCommand):
+
+    def run(self, args):
+        f = Figlet(font='slant')
+        print(f.renderText('Eukaryote Interactive'))
+
+        action_choices = ['Attack a model with attack_eval', 'Adversarial training with attack_train', 'Train a model with train']
+        model_choices = ['distilbert-base-uncased', 'BERT_mini', 'BERT_regular', 'BERT_large', 'BagOfWords']
+        dataset_choices = ['rotten_tomatoes']
+        attack_choices = ['textfooler']
+
+        questions = [
+            {
+                'message': 'Select an action:',
+                'type': 'list',
+                'choices': action_choices,
+                'name': 'action',
+            },
+            {
+                'message': 'Select a model:',
+                'type': 'fuzzy',
+                'choices': model_choices,
+                'name': 'model_huggingface',
+            },
+            {
+                'message': 'Select a dataset:',
+                'type': 'fuzzy',
+                'choices': dataset_choices,
+                'name': 'dataset_huggingface',
+            },
+            {
+                'message': 'Select an attack recipe:',
+                'type': 'fuzzy',
+                'choices': attack_choices,
+                'name': 'attack_recipe',
+            },
+            {'message': 'Confirm?', 'type': 'confirm', 'default': False, 'name':'confirmation'},
+        ]
+
+        try:
+            arguments = prompt(questions, vi_mode=True) # decide which action to take
+            if arguments['action'] == 'Attack a model with attack_eval':
+                parser_fake = ArgumentParser() # copy t4a_attack_eval_command.py's register_subcommand behavior
+                shared.add_arguments_model(parser_fake)
+                shared.add_arguments_dataset(parser_fake, default_split="test")
+                shared.add_arguments_attack(parser_fake)
+                parser_fake.set_defaults(attack=True)
+                newArgs = parser_fake.parse_args([f"--{k}={v}" for k, v in arguments.items() if k != 'action' and k != 'confirmation'])
+                T4A_AttackEvalCommand().run(args=newArgs)
+            elif arguments['action'] == 'Train a model with train': 
+                parser_fake = ArgumentParser() # copy t4a_train_command.py's register_subcommand behavior
+                shared.add_arguments_model(parser_fake)
+                shared.add_arguments_dataset(parser_fake, default_split="train")
+                shared.add_arguments_train(parser_fake, default_split_eval="test")
+                parser_fake.set_defaults(attack=False)
+                newArgs = parser_fake.parse_args([f"--{k}={v}" for k, v in arguments.items() if k != 'action' and k != 'confirmation' and k != 'attack_recipe'])
+                T4A_TrainCommand().run(args=newArgs)
+            elif arguments['action'] == 'Adversarial training with attack_train': 
+                parser_fake = ArgumentParser() # copy t4a_attack_train_command.py's register_subcommand behavior
+                shared.add_arguments_model(parser_fake)
+                shared.add_arguments_dataset(parser_fake, default_split="train")
+                shared.add_arguments_attack(parser_fake)
+                shared.add_arguments_train(parser_fake)
+                parser_fake.set_defaults(attack=True)
+                newArgs = parser_fake.parse_args([f"--{k}={v}" for k, v in arguments.items() if k != 'action' and k != 'confirmation'])
+                T4A_AttackTrainCommand().run(args=newArgs)
+        except InvalidArgument:
+            print('No available choices')
+
+    @staticmethod
+    def register_subcommand(main_parser: ArgumentParser):
+        parser_interactive = main_parser.add_parser(
+            'interactive',
+            help='start the interactive CLI to run a T4A command',
+            formatter_class=ArgumentDefaultsHelpFormatter,
+        )
+        parser_interactive.set_defaults(func=InteractiveCliCommand())

--- a/eukaryote/commands/interactive_cli_command.py
+++ b/eukaryote/commands/interactive_cli_command.py
@@ -14,79 +14,119 @@ import eukaryote.t4a.shared as shared
 
 
 class InteractiveCliCommand(TextAttackCommand):
-
     def run(self, args):
-        f = Figlet(font='slant')
-        print(f.renderText('Eukaryote Interactive'))
+        f = Figlet(font="slant")
+        print(f.renderText("Eukaryote Interactive"))
 
-        action_choices = ['Attack a model with attack_eval', 'Adversarial training with attack_train', 'Train a model with train']
-        model_choices = ['distilbert-base-uncased', 'BERT_mini', 'BERT_regular', 'BERT_large', 'BagOfWords']
-        dataset_choices = ['rotten_tomatoes']
-        attack_choices = ['textfooler']
+        action_choices = [
+            "Attack a model with attack_eval",
+            "Adversarial training with attack_train",
+            "Train a model with train",
+        ]
+        model_choices = [
+            "distilbert-base-uncased",
+            "BERT_mini",
+            "BERT_regular",
+            "BERT_large",
+            "BagOfWords",
+        ]
+        dataset_choices = ["rotten_tomatoes"]
+        attack_choices = ["textfooler"]
 
         questions = [
             {
-                'message': 'Select an action:',
-                'type': 'list',
-                'choices': action_choices,
-                'name': 'action',
+                "message": "Select an action:",
+                "type": "list",
+                "choices": action_choices,
+                "name": "action",
             },
             {
-                'message': 'Select a model:',
-                'type': 'fuzzy',
-                'choices': model_choices,
-                'name': 'model_huggingface',
+                "message": "Select a model:",
+                "type": "fuzzy",
+                "choices": model_choices,
+                "name": "model_huggingface",
             },
             {
-                'message': 'Select a dataset:',
-                'type': 'fuzzy',
-                'choices': dataset_choices,
-                'name': 'dataset_huggingface',
+                "message": "Select a dataset:",
+                "type": "fuzzy",
+                "choices": dataset_choices,
+                "name": "dataset_huggingface",
             },
             {
-                'message': 'Select an attack recipe:',
-                'type': 'fuzzy',
-                'choices': attack_choices,
-                'name': 'attack_recipe',
+                "message": "Select an attack recipe:",
+                "type": "fuzzy",
+                "choices": attack_choices,
+                "name": "attack_recipe",
             },
-            {'message': 'Confirm?', 'type': 'confirm', 'default': False, 'name':'confirmation'},
+            {
+                "message": "Confirm?",
+                "type": "confirm",
+                "default": False,
+                "name": "confirmation",
+            },
         ]
 
         try:
-            arguments = prompt(questions, vi_mode=True) # decide which action to take
-            if arguments['action'] == 'Attack a model with attack_eval':
-                parser_fake = ArgumentParser() # copy t4a_attack_eval_command.py's register_subcommand behavior
+            arguments = prompt(questions, vi_mode=True)  # decide which action to take
+            if arguments["action"] == "Attack a model with attack_eval":
+                parser_fake = (
+                    ArgumentParser()
+                )  # copy t4a_attack_eval_command.py's register_subcommand behavior
                 shared.add_arguments_model(parser_fake)
                 shared.add_arguments_dataset(parser_fake, default_split="test")
                 shared.add_arguments_attack(parser_fake)
                 parser_fake.set_defaults(attack=True)
-                newArgs = parser_fake.parse_args([f"--{k}={v}" for k, v in arguments.items() if k != 'action' and k != 'confirmation'])
+                newArgs = parser_fake.parse_args(
+                    [
+                        f"--{k}={v}"
+                        for k, v in arguments.items()
+                        if k != "action" and k != "confirmation"
+                    ]
+                )
                 T4A_AttackEvalCommand().run(args=newArgs)
-            elif arguments['action'] == 'Train a model with train': 
-                parser_fake = ArgumentParser() # copy t4a_train_command.py's register_subcommand behavior
+            elif arguments["action"] == "Train a model with train":
+                parser_fake = (
+                    ArgumentParser()
+                )  # copy t4a_train_command.py's register_subcommand behavior
                 shared.add_arguments_model(parser_fake)
                 shared.add_arguments_dataset(parser_fake, default_split="train")
                 shared.add_arguments_train(parser_fake, default_split_eval="test")
                 parser_fake.set_defaults(attack=False)
-                newArgs = parser_fake.parse_args([f"--{k}={v}" for k, v in arguments.items() if k != 'action' and k != 'confirmation' and k != 'attack_recipe'])
+                newArgs = parser_fake.parse_args(
+                    [
+                        f"--{k}={v}"
+                        for k, v in arguments.items()
+                        if k != "action"
+                        and k != "confirmation"
+                        and k != "attack_recipe"
+                    ]
+                )
                 T4A_TrainCommand().run(args=newArgs)
-            elif arguments['action'] == 'Adversarial training with attack_train': 
-                parser_fake = ArgumentParser() # copy t4a_attack_train_command.py's register_subcommand behavior
+            elif arguments["action"] == "Adversarial training with attack_train":
+                parser_fake = (
+                    ArgumentParser()
+                )  # copy t4a_attack_train_command.py's register_subcommand behavior
                 shared.add_arguments_model(parser_fake)
                 shared.add_arguments_dataset(parser_fake, default_split="train")
                 shared.add_arguments_attack(parser_fake)
                 shared.add_arguments_train(parser_fake)
                 parser_fake.set_defaults(attack=True)
-                newArgs = parser_fake.parse_args([f"--{k}={v}" for k, v in arguments.items() if k != 'action' and k != 'confirmation'])
+                newArgs = parser_fake.parse_args(
+                    [
+                        f"--{k}={v}"
+                        for k, v in arguments.items()
+                        if k != "action" and k != "confirmation"
+                    ]
+                )
                 T4A_AttackTrainCommand().run(args=newArgs)
         except InvalidArgument:
-            print('No available choices')
+            print("No available choices")
 
     @staticmethod
     def register_subcommand(main_parser: ArgumentParser):
         parser_interactive = main_parser.add_parser(
-            'interactive',
-            help='start the interactive CLI to run a T4A command',
+            "interactive",
+            help="start the interactive CLI to run a T4A command",
             formatter_class=ArgumentDefaultsHelpFormatter,
         )
         parser_interactive.set_defaults(func=InteractiveCliCommand())

--- a/eukaryote/commands/interactive_cli_command.py
+++ b/eukaryote/commands/interactive_cli_command.py
@@ -66,59 +66,40 @@ class InteractiveCliCommand(TextAttackCommand):
             },
         ]
 
+        # semi-redundant code here, but I have a feeling keeping them separate is more clear+extensible?
         try:
-            arguments = prompt(questions, vi_mode=True)  # decide which action to take
-            if arguments["action"] == "Attack a model with attack_eval":
-                parser_fake = (
-                    ArgumentParser()
-                )  # copy t4a_attack_eval_command.py's register_subcommand behavior
-                shared.add_arguments_model(parser_fake)
-                shared.add_arguments_dataset(parser_fake, default_split="test")
-                shared.add_arguments_attack(parser_fake)
-                parser_fake.set_defaults(attack=True)
-                newArgs = parser_fake.parse_args(
-                    [
-                        f"--{k}={v}"
-                        for k, v in arguments.items()
-                        if k != "action" and k != "confirmation"
-                    ]
-                )
-                T4A_AttackEvalCommand().run(args=newArgs)
-            elif arguments["action"] == "Train a model with train":
-                parser_fake = (
-                    ArgumentParser()
-                )  # copy t4a_train_command.py's register_subcommand behavior
-                shared.add_arguments_model(parser_fake)
-                shared.add_arguments_dataset(parser_fake, default_split="train")
-                shared.add_arguments_train(parser_fake, default_split_eval="test")
-                parser_fake.set_defaults(attack=False)
-                newArgs = parser_fake.parse_args(
-                    [
-                        f"--{k}={v}"
-                        for k, v in arguments.items()
-                        if k != "action"
-                        and k != "confirmation"
-                        and k != "attack_recipe"
-                    ]
-                )
-                T4A_TrainCommand().run(args=newArgs)
-            elif arguments["action"] == "Adversarial training with attack_train":
-                parser_fake = (
-                    ArgumentParser()
-                )  # copy t4a_attack_train_command.py's register_subcommand behavior
-                shared.add_arguments_model(parser_fake)
-                shared.add_arguments_dataset(parser_fake, default_split="train")
-                shared.add_arguments_attack(parser_fake)
-                shared.add_arguments_train(parser_fake)
-                parser_fake.set_defaults(attack=True)
-                newArgs = parser_fake.parse_args(
-                    [
-                        f"--{k}={v}"
-                        for k, v in arguments.items()
-                        if k != "action" and k != "confirmation"
-                    ]
-                )
-                T4A_AttackTrainCommand().run(args=newArgs)
+            prompt_action = prompt(questions[0], vi_mode=True)  # decide which action to take
+            if prompt_action["action"] == "Attack a model with attack_eval":
+                prompt_args = prompt([questions[i] for i in [1,2,3,4]], vi_mode=True)  # set up to select arbitrary subset of questions
+                fake_parser = ArgumentParser()
+                # copy t4a_attack_eval_command.py's register_subcommand behavior
+                shared.add_arguments_model(fake_parser)
+                shared.add_arguments_dataset(fake_parser, default_split="test")
+                shared.add_arguments_attack(fake_parser)
+                fake_parser.set_defaults(attack=True)
+                fake_args = fake_parser.parse_args([f"--{k}={v}" for k, v in prompt_args.items() if k != 'confirmation']) # format for parser
+                T4A_AttackEvalCommand().run(args=fake_args)
+            elif prompt_action["action"] == "Train a model with train":
+                prompt_args = prompt([questions[i] for i in [1,2,4]], vi_mode=True) # no need to ask q3, attack recipe. Set up to select arbitrary subset of questions
+                fake_parser = ArgumentParser()
+                # copy t4a_train_command.py's register_subcommand behavior
+                shared.add_arguments_model(fake_parser)
+                shared.add_arguments_dataset(fake_parser, default_split="train")
+                shared.add_arguments_train(fake_parser, default_split_eval="test")
+                fake_parser.set_defaults(attack=False)
+                fake_args = fake_parser.parse_args([f"--{k}={v}" for k, v in prompt_args.items() if k != 'confirmation']) # format for parser
+                T4A_TrainCommand().run(args=fake_args)
+            elif prompt_action["action"] == "Adversarial training with attack_train":
+                prompt_args = prompt([questions[i] for i in [1,2,3,4]], vi_mode=True) # set up to select arbitrary subset of questions
+                fake_parser = ArgumentParser()
+                # copy t4a_attack_train_command.py's register_subcommand behavior
+                shared.add_arguments_model(fake_parser)
+                shared.add_arguments_dataset(fake_parser, default_split="train")
+                shared.add_arguments_attack(fake_parser)
+                shared.add_arguments_train(fake_parser)
+                fake_parser.set_defaults(attack=True)
+                fake_args = fake_parser.parse_args([f"--{k}={v}" for k, v in prompt_args.items() if k != 'confirmation']) # format for parser
+                T4A_AttackTrainCommand().run(args=fake_args)
         except InvalidArgument:
             print("No available choices")
 

--- a/eukaryote/commands/textattack_cli.py
+++ b/eukaryote/commands/textattack_cli.py
@@ -22,6 +22,8 @@ from eukaryote.commands.t4a_attack_eval_command import T4A_AttackEvalCommand
 from eukaryote.commands.t4a_attack_train_command import T4A_AttackTrainCommand
 from eukaryote.commands.t4a_train_command import T4A_TrainCommand
 
+from eukaryote.commands.interactive_cli_command import InteractiveCliCommand
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -44,6 +46,8 @@ def main():
     T4A_AttackEvalCommand.register_subcommand(subparsers)
     T4A_AttackTrainCommand.register_subcommand(subparsers)
     T4A_TrainCommand.register_subcommand(subparsers)
+
+    InteractiveCliCommand.register_subcommand(subparsers)
 
     # Let's go
     args = parser.parse_args()


### PR DESCRIPTION
Adds another command to the CLI, with the command "eukaryote interactive". This opens up David's interactive CLI (https://github.com/dhpitt/dummycli) and walks the user through choosing one of the three T4A commands and selecting options for all required arguments. Very rudimentary at the moment.

Internally, works by creating an argparse Parser object, running T4A's code to load up default arguments and such that's usually in register_subcommand(), and loads the arguments collected from the interactive CLI into the Parser as if they'd been collected from the command line. Hopefully this means the results of an instruction executed with "interactive" will be identical to if they'd run the command directly with those arguments.